### PR TITLE
fix: fullscreen fallback + toast hint when API blocked

### DIFF
--- a/src/app/tesla/_components/dashboard.tsx
+++ b/src/app/tesla/_components/dashboard.tsx
@@ -185,6 +185,7 @@ const Dashboard: React.FC<{ defaults: DashboardApp[] }> = ({ defaults }) => {
   const [showAddModal, setShowAddModal] = useState(false);
   const [carName, setCarName] = useState<string>(DEFAULT_CAR_NAME);
   const [tempUnit, setTempUnit] = useState<TempUnit>("celsius");
+  const [fullscreenHint, setFullscreenHint] = useState<string | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -300,14 +301,42 @@ const Dashboard: React.FC<{ defaults: DashboardApp[] }> = ({ defaults }) => {
   }, []);
 
   const toggleFullscreen = useCallback(async () => {
+    type LegacyDoc = Document & {
+      webkitFullscreenElement?: Element;
+      webkitExitFullscreen?: () => Promise<void> | void;
+    };
+    type LegacyEl = HTMLElement & {
+      webkitRequestFullscreen?: () => Promise<void> | void;
+    };
+    const doc = document as LegacyDoc;
+    const root = document.documentElement as LegacyEl;
+    const inFullscreen = !!doc.fullscreenElement || !!doc.webkitFullscreenElement;
+
     try {
-      if (!document.fullscreenElement) {
-        await document.documentElement.requestFullscreen();
-      } else {
-        await document.exitFullscreen();
+      if (inFullscreen) {
+        if (doc.exitFullscreen) {
+          await doc.exitFullscreen();
+        } else if (doc.webkitExitFullscreen) {
+          await doc.webkitExitFullscreen();
+        }
+        return;
       }
+      if (root.requestFullscreen) {
+        await root.requestFullscreen();
+        return;
+      }
+      if (root.webkitRequestFullscreen) {
+        await root.webkitRequestFullscreen();
+        return;
+      }
+      throw new Error("Fullscreen API unavailable");
     } catch {
-      // some browsers (incl. Tesla in-car) may reject — fail silently
+      // Tesla's in-car browser blocks the Fullscreen API. Surface a hint so the
+      // tap doesn't look broken; user can use Tesla Theater mode for true FS.
+      setFullscreenHint(
+        "Fullscreen blocked by browser. On Tesla, use Theater mode.",
+      );
+      window.setTimeout(() => setFullscreenHint(null), 4000);
     }
   }, []);
 
@@ -449,6 +478,11 @@ const Dashboard: React.FC<{ defaults: DashboardApp[] }> = ({ defaults }) => {
         onClose={() => setShowAddModal(false)}
         onAdd={handleAdd}
       />
+      {fullscreenHint && (
+        <div className="tesla-toast" role="status" aria-live="polite">
+          {fullscreenHint}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/tesla/tesla.css
+++ b/src/app/tesla/tesla.css
@@ -771,6 +771,39 @@ html[data-tesla-theme="dark"] .tesla-logo-img {
   margin-top: 4px;
 }
 
+/* Toast (transient hints — fullscreen failure, etc.) */
+.tesla-toast {
+  position: absolute;
+  left: 50%;
+  bottom: clamp(80px, 10vh, 120px);
+  transform: translateX(-50%);
+  z-index: 50;
+  padding: 12px 20px;
+  border-radius: 9999px;
+  background: var(--tesla-surface-2);
+  border: 1px solid var(--tesla-border);
+  box-shadow: var(--tesla-shadow-lift);
+  color: var(--tesla-text-primary);
+  font-size: clamp(13px, 0.95vw, 14px);
+  font-weight: 500;
+  white-space: nowrap;
+  max-width: calc(100% - 48px);
+  text-align: center;
+  pointer-events: none;
+  animation: tesla-toast-in 240ms cubic-bezier(0.2, 0.7, 0.3, 1);
+}
+
+@keyframes tesla-toast-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 6px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
 /* Error fallback */
 .tesla-error {
   flex: 1;
@@ -807,6 +840,7 @@ html[data-tesla-theme="dark"] .tesla-logo-img {
   .tesla-idle,
   .tesla-modal,
   .tesla-modal-backdrop,
+  .tesla-toast,
   .tw-sun-rays,
   .tw-sun-rays-small,
   .tw-cloud-drift,


### PR DESCRIPTION
The Fullscreen API is blocked in Tesla's in-car browser, so the Fullscreen pill on `/tesla` was silently doing nothing when tapped — looked broken.

`toggleFullscreen` now tries the modern API, falls back to `webkitRequestFullscreen` (old Chromium), and mirrors the same chain on exit; if both paths fail, a small bottom-centered toast surfaces ("Fullscreen blocked by browser. On Tesla, use Theater mode.") and auto-dismisses after 4s. Desktop behaviour is unchanged — the toast only appears when the API is actually rejected.